### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://github.com/lmtm/gulp-marked",
   "bugs": "https://github.com/lmtm/gulp-marked/issues",
   "author": "Thomas Moyse <tmoyse@gmail.com>",
+  "repository": "lmtm/gulp-marked",
   "dependencies": {
     "marked": "~0.3.2",
     "bufferstreams": "0.0.1",


### PR DESCRIPTION
This addresses the following warning, which NPM currently prints when
gulp-marked is installed.

    npm WARN package.json gulp-marked@1.0.0 No repository field.